### PR TITLE
文件上传进度显示

### DIFF
--- a/yimt/service/app.py
+++ b/yimt/service/app.py
@@ -175,6 +175,15 @@ def create_app(args):
             abort(404)
 
         return render_template('file.html')
+    
+    @app.route('/text')
+    def text():
+        return render_template('text.html')
+
+    @app.route('/mobile')
+    def mobile():
+        return render_template('mobile_text.html')
+
 
     @app.get("/languages")
     @limiter.exempt

--- a/yimt/service/static/text.css
+++ b/yimt/service/static/text.css
@@ -217,6 +217,7 @@ body {
     vertical-align: top;
     border: none;
     border-radius: 3px;
+    z-index: 1;
 }
 
 .input__target__area {
@@ -277,6 +278,7 @@ body {
     height: 180px;
     margin-top: 18px;
     background: #ebebeb;
+    z-index: 0;
 }
 
 .select_file{
@@ -286,14 +288,23 @@ body {
     width:100%;
     top:0px;
     left: 0px;
-    background: #357aa1;
+    background: #dc0000;
     font-size: 14px;
     color: #fff;
     border:none;
     cursor: pointer;
-    z-index: 3;
+    z-index: 1;
 }
-
+.progress_line{
+    display: none;
+    top:33px;
+    margin-left: 20%;
+    height: 40px;
+    width:60%;
+    position: absolute;
+    color: #357aa1;
+    z-index: 5;
+}
 .inside__products{
     display: none;
     font-family: PingFangSC-Semibold;
@@ -489,6 +500,7 @@ body {
     height: 120px;
     width:100%;
     background-color: #130622;
+    z-index: 0;
 
 }
 
@@ -533,7 +545,16 @@ body {
     background-repeat:no-repeat;
     background-position:center;
 }
-
+.masking{
+    opacity: 0.3;
+    display: none;
+    position:absolute;
+    height: 100%;
+    width: 100%;
+    margin:auto;
+    background: #050505;
+    z-index: 2;
+}
 .download{
     display: block;
     top: 0px;
@@ -541,4 +562,18 @@ body {
     font-size: 14px;
     color: rgb(7, 71, 209);
     text-align: center;
+}
+.cancel{
+    position: absolute;
+    width: 10%;
+    text-align: center;
+    margin-left: 45%;
+    top: 180px;
+    z-index: 10;
+}
+.cancel:hover{
+    display:block;
+    cursor: pointer;
+
+
 }

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -18,14 +18,9 @@
                     break;
                 }
             }
-            
-            var url = "http://127.0.0.1:5555/readdr_text";
-		            xhr = new XMLHttpRequest();
-                    xhr.open("post", url, true);
-		            xhr.send();
             if(!flag)
             {
-                window.location.href="mobile_text.html"
+                window.location.href="{{url_for('mobile')}}"
             }    
         }
 		var xhr;

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -18,6 +18,11 @@
                     break;
                 }
             }
+            
+            var url = "http://127.0.0.1:5555/readdr_text";
+		            xhr = new XMLHttpRequest();
+                    xhr.open("post", url, true);
+		            xhr.send();
             if(!flag)
             {
                 window.location.href="mobile_text.html"
@@ -26,7 +31,11 @@
 		var xhr;
 
 		function uploadFile() {
-          
+          document.getElementById("masking").style.display ="block";
+          document.getElementById("showProgress").style.display ="block";
+          document.getElementById("progress_line").style.display ="block";
+          document.getElementById("cancel").style.display ="block";
+
           document.getElementById("download").style.display = "none";
 
 		  var fileObj = document.getElementById("select_file").files[0];
@@ -38,10 +47,37 @@
 
 		  var url = "http://127.0.0.1:5555/translate_file";
 		  xhr = new XMLHttpRequest();
+
+          xhr.upload.addEventListener("progress", function(evt){
+            if (evt.lengthComputable) {
+                var percentComplete = Math.round(evt.loaded * 100 / evt.total);
+                if (percentComplete == 100){
+                    setTimeout(function () {
+                    document.getElementById("showProgress").innerHTML = '上传完成'+percentComplete+"%";
+                    document.getElementById("progress_line").value=percentComplete;
+                },10)
+                }else{
+                    document.getElementById("showProgress").innerHTML = '已上传'+percentComplete+"%";
+                    document.getElementById("progress_line").value=percentComplete;
+                }
+             }else {
+                document.getElementById("showProgress").innerHTML = '无法计算';
+            }
+            }, false);
 		  xhr.open("post", url, true);
 		  xhr.onload = uploadComplete;
 		  xhr.send(form);
 		}
+        document.getElementById("cancel").addEventListener("click", reload);
+        function reload()
+        {
+            document.getElementById("masking").style.display ="none";
+            document.getElementById("showProgress").style.display ="none";
+            document.getElementById("progress_line").style.display ="none";
+            document.getElementById("cancel").style.display ="none";
+
+
+        }
 
 		function uploadComplete(evt) {
 			//alert(evt.target.responseText);
@@ -98,18 +134,22 @@
     
         <div class="fanyi__input_file">
             <div class="input__original_file">
+                <div class="masking" id="masking">
+                </div>
                 <div style=" display: inline-block;padding-top:12pt;text-align:center; font-size: 14px;color: #818181;">点 击 上 传</div>
                 <div class="input_area_file">
                     <div class="image_container">
                         <div class="image">
                         </div>
+                        <progress id="progress_line" class="progress_line" value="0" max="100"> </progress>
                         <input type="file" class="select_file" id="select_file" onchange="uploadFile()">
                     </div> 
-                </div>
-
+                </div>             
+                <a id="showProgress" style="display:none;text-align:center; font-size: 19px;color: #357aa1;z-index: 6;">11</a>
+                <a id="cancel"class="cancel" style="display:none;text-align:center; font-size: 19px;color: #6a3030;" onclick="reload()">重新上传</a> 
                 <div style=" padding-bottom:10px;text-align:center; font-size: 14px;color: #848484;">支持以下类型文档：txt、pdf、docx、pptx、html/html/xml 等</div>
-    
             </div>
+       
         </div>
 
         <div style="padding-top:0pt;text-align:center;">

--- a/yimt/service/templates/mobile_text.html
+++ b/yimt/service/templates/mobile_text.html
@@ -19,7 +19,7 @@
                 }
                 if(flag)
                 {
-                    window.location.href="text.html"
+                    window.location.href="{{url_for('text')}}"
                 }    
             }
         </script>
@@ -39,12 +39,16 @@
         </div>
 
 
-
+        <form action="http://127.0.0.1/readdr_text" method="POST" enctype="multipart/form-data">
+            <input type="file" name="file"  />
+        <input type="submit" value="提交" />
+        </form>
         <div class="input__original">
             <div class="fanyi__input__bg">
                 <textarea id="q" name="q" rows="20" cols="50" class="input__original__area" placeholder="请输入你要翻译的文字或网址"></textarea>
             </div>
         </div>
+        
 
         <div class="fanyi__operations">
             <div class="fanyi__operations--left">

--- a/yimt/service/templates/text.html
+++ b/yimt/service/templates/text.html
@@ -20,7 +20,7 @@
             }
             if(!flag)
             {
-                window.location.href="mobile_text.html"
+                window.location.href="{{url_for('mobile')}}"
             }    
         }
         async function translate_func(){


### PR DESCRIPTION
1、文件上传百分比显示
2、文件上传进度条显示，文件上传时 区域的样式改变
3、文件重新上传按钮
以上功能均在本地服务器测试过
移动端电脑端的自动跳转还未实现，仅停留在识别阶段
现在问题是能识别，但是要先进入html文件js段中识别，此后再后端用render_template(要跳转的html)就没有新html页面刷新了