### PR TITLE
Web更新3.16

### DIFF
--- a/yimt/service/static/text.css
+++ b/yimt/service/static/text.css
@@ -45,6 +45,11 @@ body {
     right: 58px;
 }
 
+
+.url_setting_block{
+    display: block;
+}
+
 .restriction{
     margin-left: 60px;
     margin-right: 60px;
@@ -347,6 +352,7 @@ body {
     color: #999;
     white-space:pre;
     margin-left: 22px;
+    cursor: pointer;
 }
 
 .nav2{
@@ -552,3 +558,5 @@ body {
     color: rgb(7, 71, 209);
     text-align: center;
 }
+
+

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -3,8 +3,12 @@
 <html>
 <head> 
     <link rel="stylesheet" type="text/css" href="../static/text.css">
-
+    
     <script>
+        var netloc="127.0.0.1:5555";
+        var protocol="http://";
+        var path="/translate_file";
+
         window.onload = function()
         {
             var userAgentInfo = navigator.userAgent;
@@ -24,7 +28,7 @@
             }    
         }
 		var xhr;
-
+       
 		function uploadFile() {
 		  var fileObj = document.getElementById("select_file").files[0];
           var files = document.getElementById("select_file").files;
@@ -41,8 +45,9 @@
 		  form.append("file", fileObj);
 		  form.append("source", "en");
 		  form.append("target", "zh");
-
-		  var url = "http://127.0.0.1:5555/translate_file";
+          
+          
+		  var url = protocol+netloc+path;
 		  xhr = new XMLHttpRequest();
 
           xhr.upload.addEventListener("progress", function(evt){
@@ -89,9 +94,30 @@
         <div class="fanyi__nav__container">
             <a href="/" class="fanyi__nav__logo"></a>
             <div class="nav_left">
-                <a target="_blank" class="nav" href="/">文本翻译</a><a target="_blank" class="nav" href="/">翻译API</a><a target="_blank" class="nav" href="/">登录</a>
+                <a target="_blank" class="nav" href="/">文本翻译</a><a target="_blank" class="nav" href="/">翻译API</a><a target="_blank" class="nav" href="/">登录</a><a target="_blank" id="url_setting_label" class="nav" >设置服务器地址</a>
             </div>
         </div>
+        <div class="url_setting_block" id="url_setting_block" style="visibility: hidden;">
+            <textarea calss="url" id="url" placeholder="127.0.0.1:5555"></textarea>
+            <input type="button" class="url_button" id="url_button" value="重置翻译服务器地址" onclick="url_resetting_func()">
+            <input type="button" class="url_setting_hide" id="url_setting_hide" value="关闭" onclick="url_setting_hide_func()">
+        </div>
+        <script>
+            function url_setting_func()
+            {
+                document.getElementById("url_setting_block").style.visibility='visible';
+            }
+            function url_resetting_func()
+            {
+                netloc = document.getElementById("url").value;
+                alert("重置成功！重置后的url为："+protocol+netloc);
+            }
+            function url_setting_hide_func()
+            {
+                document.getElementById("url_setting_block").style.visibility='hidden';
+            }
+            document.getElementById("url_setting_label").addEventListener("click", url_setting_func);
+        </script>
     </div>
 
     <div class="restriction">

--- a/yimt/service/templates/text.html
+++ b/yimt/service/templates/text.html
@@ -5,8 +5,13 @@
     <link rel="stylesheet" type="text/css" href="../static/text.css">
 
     <script>
+        var netloc="127.0.0.1:5555";
+        var protocol="http://";
+        var path="/translate";
+
         window.onload = function()
         {
+            
             var userAgentInfo = navigator.userAgent;
             var Agents = ["Android","iPhone","SymbianOS","Windows Phone","iPad","iPod"];
             var flag = true;
@@ -29,8 +34,9 @@
           if(qstr.length==0) return;
           source_lang = document.getElementById('source').value
           target_lang = document.getElementById('target').value
-          
-          const res = await fetch("http://127.0.0.1:5555/translate", {
+        
+          var url_trans=netloc+protocol+path;
+          const res = await fetch(url_trans, {
             method: "POST",
             body: JSON.stringify({q: qstr, source: source_lang, target: target_lang, format: "text"}),
             headers: { "Content-Type": "application/json" }
@@ -50,10 +56,31 @@
         <div class="fanyi__nav__container">
                 <a href="/" class="fanyi__nav__logo"></a>
             <div class="nav_left">
-                <a target="_blank" class="nav" href="/file">文档翻译</a><a target="_blank" class="nav" href="/">翻译API</a><a target="_blank" class="nav" href="/">登录</a>
+                <a target="_blank" class="nav" href="/file">文档翻译</a><a target="_blank" class="nav" href="/">翻译API</a><a target="_blank" class="nav" href="/">登录</a><a target="_blank" id="url_setting_label" class="nav" >设置服务器地址</a>
             </div>
                 
-        </div>    
+        </div>
+        <div class="url_setting_block" id="url_setting_block" style="visibility: hidden;">
+            <textarea calss="url" id="url" placeholder="127.0.0.1:5555"></textarea>
+            <input type="button" class="url_button" id="url_button" value="重置翻译服务器地址" onclick="url_resetting_func()">
+            <input type="button" class="url_setting_hide" id="url_setting_hide" value="关闭" onclick="url_setting_hide_func()">
+        </div>
+        <script>
+            function url_setting_func()
+            {
+                document.getElementById("url_setting_block").style.visibility='visible';
+            }
+            function url_resetting_func()
+            {
+                netloc = document.getElementById("url").value;
+                alert("重置成功！重置后的url为："+protocol+netloc);
+            }
+            function url_setting_hide_func()
+            {
+                document.getElementById("url_setting_block").style.visibility='hidden';
+            }
+            document.getElementById("url_setting_label").addEventListener("click", url_setting_func);
+        </script> 
 
     </div>
 


### PR DESCRIPTION
增加了自定义翻译地址功能：（在文本翻译和文档翻译中）
1、点击导航栏右端的“设置翻译地址”，显示翻译地址设置界面。
2、翻译地址设置界面中，输入地址，点击重置按钮，重置翻译地址，并弹窗提示重置结果。
3、翻译地址设置界面中，点击关闭按钮，关闭翻译地址设置界面。