### PR TITLE
Web开发更新3.25

### DIFF
--- a/yimt/service/static/text.css
+++ b/yimt/service/static/text.css
@@ -64,6 +64,24 @@ body {
 .url_setting_block:hover{
     box-shadow: 0px 0 20px 7px rgba(0, 0, 0, 0.5);
 }
+.api_key_block{
+    display: block;
+    position: absolute;
+    border: #2b2b2b;
+    border-width: 3px;
+    border-radius: 5px;
+    width: 260px;
+    height: 200px;
+    top:30px;
+    right: 20%;
+    opacity:1;
+    box-shadow: 0px 0 20px 3px rgba(0, 0, 0, 0.5);
+    background-color: #ffffff;
+    z-index: 6;
+}
+.api_key_block:hover{
+    box-shadow: 0px 0 20px 7px rgba(0, 0, 0, 0.5);
+}
 .mask{
     display: none;
     position:absolute;

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -10,12 +10,11 @@
         window.onload = function()
         {
             var json1=window.localStorage.getItem("data");
-            alert(json1);
+            //alert(json1);
             if(json1=="")
             {
-                end_point=="http://127.0.0.1:5555/translate";
-                alert("sss");//
-                alert(end_point);//
+                end_point = "http://127.0.0.1:5555/translate";
+                //alert(end_point);//
                 //http://127.0.0.1:5555/api_key_get
             }
             else{
@@ -106,10 +105,10 @@
         <div class="url_setting_hide" id="url_setting_hide" style="cursor:pointer; position:absolute ;top:20px;left: 30px;width: 20px;height: 20px;"onclick="url_setting_hide_func()">
             <div class="arrow_image"></div>
         </div>
-        <div style="position:absolute; top:60px;left: 30px;">
+        <div style="position:absolute; top:65px;left: 30px;">
             <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:5px;width: 200px;text-align: left;">服务器端点</label>
-            <textarea class="url" id="url" rows="1" cols="20" placeholder="http://127.0.0.1:5555/translate" style="position:absolute;letter-spacing: 0px;font-size: 14px;top: 30px;"></textarea>
-            <input type="button" class="url_button" id="url_button" style="position: absolute;top:57px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
+            <textarea class="url" id="url" rows="1" cols="20" placeholder="http://127.0.0.1:5555/translate" wrap="off" style="position:absolute;width: 193.5px;height:21px;letter-spacing: 0px;font-size: 14px;top: 30px;"></textarea>
+            <input type="button" class="url_button" id="url_button" style="position: absolute;top:67px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
         </div>
     </div>
     <div class="api_key_block" id="api_key_block" style="visibility: hidden;">
@@ -136,7 +135,8 @@
             {
                 document.getElementById("url_setting_block").style.visibility='visible';
                 document.getElementById("mask").style.display='block';
-                alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
+                console.log("当前翻译地址为："+end_point);
+                //alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
             }
             function api_key_func()
             {
@@ -159,13 +159,18 @@
             async function api_key_check_func()//
             {
                 var api_key = document.getElementById("api_key").value;
-                const res = await fetch(end_point, {
+
+                window.localStorage.setItem("key",api_key);
+                //var key=window.localStorage.getItem("key");
+                //alert(key);
+                const res = await fetch("http://127.0.0.1:5555/get_req_api_key", {
                 method: "POST",
                 body: JSON.stringify({api_key:api_key}),
                 headers: { "Content-Type": "application/json" }
                 }
                 );
                 alert("输入成功");
+                url_setting_hide_func();
             }
             function url_setting_hide_func()
             {

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -10,10 +10,12 @@
         window.onload = function()
         {
             var json1=window.localStorage.getItem("data");
-            var jsonObj1=JSON.parse(json1);
-            if(jsonObj1=="")
+            alert(json1);
+            if(json1=="")
             {
                 end_point=="http://127.0.0.1:5555/translate";
+                alert("sss");//
+                alert(end_point);//
                 //http://127.0.0.1:5555/api_key_get
             }
             else{
@@ -105,9 +107,9 @@
             <div class="arrow_image"></div>
         </div>
         <div style="position:absolute; top:60px;left: 30px;">
-            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:0px;width: 200px;text-align: left;">服务器端点</label>
-            <textarea class="url" id="url" placeholder="http://127.0.0.1:5555/translate" style="position:absolute;font-size: 16px;height:35px;width: 194px;top: 25px;"></textarea>
-            <input type="button" class="url_button" id="url_button" style="position: absolute;top:77px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
+            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:5px;width: 200px;text-align: left;">服务器端点</label>
+            <textarea class="url" id="url" rows="1" cols="20" placeholder="http://127.0.0.1:5555/translate" style="position:absolute;letter-spacing: 0px;font-size: 14px;top: 30px;"></textarea>
+            <input type="button" class="url_button" id="url_button" style="position: absolute;top:57px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
         </div>
     </div>
     <div class="api_key_block" id="api_key_block" style="visibility: hidden;">
@@ -133,7 +135,7 @@
             function url_setting_func()
             {
                 document.getElementById("url_setting_block").style.visibility='visible';
-                document.getElementById("mask").style.display='block'
+                document.getElementById("mask").style.display='block';
                 alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
             }
             function api_key_func()
@@ -150,6 +152,9 @@
                 window.localStorage.setItem("data",end_point);
                 var json=window.localStorage.getItem("data");
                 alert("重置成功！重置后的url为："+json);
+                document.getElementById("url_setting_block").style.visibility='hidden';
+                document.getElementById("mask").style.display='none'
+
             }
             async function api_key_check_func()//
             {

--- a/yimt/service/templates/text.html
+++ b/yimt/service/templates/text.html
@@ -6,14 +6,15 @@
 
     <script>
         var end_point;
-
+        
         window.onload = function()
         {
             var json1=window.localStorage.getItem("data");
-            var jsonObj1=JSON.parse(json1);
-            if(jsonObj1=="")
+            //alert(json1);
+            if(json1=="")
             {
-                end_point=="http://127.0.0.1:5555/translate";
+                end_point = "http://127.0.0.1:5555/translate";
+                //alert(end_point);//
                 //http://127.0.0.1:5555/api_key_get
             }
             else{
@@ -64,10 +65,10 @@
         <div class="url_setting_hide" id="url_setting_hide" style="cursor:pointer; position:absolute ;top:20px;left: 30px;width: 20px;height: 20px;"onclick="url_setting_hide_func()">
             <div class="arrow_image"></div>
         </div>
-        <div style="position:absolute; top:60px;left: 30px;">
-            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:0px;width: 200px;text-align: left;">服务器端点</label>
-            <textarea class="url" id="url" placeholder="http://127.0.0.1:5555/translate" style="position:absolute;font-size: 16px;height:35px;width: 194px;top: 25px;"></textarea>
-            <input type="button" class="url_button" id="url_button" style="position: absolute;top:77px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
+        <div style="position:absolute; top:65px;left: 30px;">
+            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:5px;width: 200px;text-align: left;">服务器端点</label>
+            <textarea class="url" id="url" rows="1" cols="20" placeholder="http://127.0.0.1:5555/translate" wrap="off" style="position:absolute;width: 193.5px;height:21px;letter-spacing: 0px;font-size: 14px;top: 30px;"></textarea>
+            <input type="button" class="url_button" id="url_button" style="position: absolute;top:67px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
         </div>
     </div>
     <div class="api_key_block" id="api_key_block" style="visibility: hidden;">
@@ -92,8 +93,9 @@
             function url_setting_func()
             {
                 document.getElementById("url_setting_block").style.visibility='visible';
-                document.getElementById("mask").style.display='block'
-                alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
+                document.getElementById("mask").style.display='block';
+                console.log("当前翻译地址为："+end_point);
+                //alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
             }
             function api_key_func()
             {
@@ -109,17 +111,25 @@
                 window.localStorage.setItem("data",end_point);
                 var json=window.localStorage.getItem("data");
                 alert("重置成功！重置后的url为："+json);
+                document.getElementById("url_setting_block").style.visibility='hidden';
+                document.getElementById("mask").style.display='none'
+
             }
             async function api_key_check_func()//
             {
                 var api_key = document.getElementById("api_key").value;
-                const res = await fetch(end_point, {
+
+                window.localStorage.setItem("key",api_key);
+                //var key=window.localStorage.getItem("key");
+                //alert(key);
+                const res = await fetch("http://127.0.0.1:5555/get_req_api_key", {
                 method: "POST",
                 body: JSON.stringify({api_key:api_key}),
                 headers: { "Content-Type": "application/json" }
                 }
                 );
                 alert("输入成功");
+                url_setting_hide_func();
             }
             function url_setting_hide_func()
             {
@@ -135,7 +145,6 @@
             document.getElementById("url_setting_label").addEventListener("click", url_setting_func);
             document.getElementById("api_key_label").addEventListener("click", api_key_func);
         </script>
-
     </div>
 
     <div class="restriction">


### PR DESCRIPTION
1、去掉翻译设置前的提示，调试使用控制台输出
2、翻译地址缺省设置，没有存储值使用固定值
3、翻译地址保存到本地，重启浏览器仍存在
4、API- KEY也像翻译地址一样保存到本地
5、地址设置使用单行编辑框（横向的滑动条）
6、点击翻译地址重置后，提示后翻译地址窗口自动关闭

（以上更新均通过了本地服务器的测试）
