### PR TITLE
Web开发更新3.26

### DIFF
--- a/yimt/service/static/text.css
+++ b/yimt/service/static/text.css
@@ -52,8 +52,8 @@ body {
     border: #2b2b2b;
     border-width: 3px;
     border-radius: 5px;
-    width: 260px;
-    height: 200px;
+    width: 360px;
+    height: 245px;
     top:30px;
     right: 20%;
     opacity:1;
@@ -64,24 +64,7 @@ body {
 .url_setting_block:hover{
     box-shadow: 0px 0 20px 7px rgba(0, 0, 0, 0.5);
 }
-.api_key_block{
-    display: block;
-    position: absolute;
-    border: #2b2b2b;
-    border-width: 3px;
-    border-radius: 5px;
-    width: 260px;
-    height: 200px;
-    top:30px;
-    right: 20%;
-    opacity:1;
-    box-shadow: 0px 0 20px 3px rgba(0, 0, 0, 0.5);
-    background-color: #ffffff;
-    z-index: 6;
-}
-.api_key_block:hover{
-    box-shadow: 0px 0 20px 7px rgba(0, 0, 0, 0.5);
-}
+
 .mask{
     display: none;
     position:absolute;

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -6,14 +6,15 @@
     
     <script>
         var end_point;
-        
+        var api_key;
         window.onload = function()
         {
             var json1=window.localStorage.getItem("data");
             //alert(json1);
+            api_key=json2;
             if(json1=="")
             {
-                end_point = "http://127.0.0.1:5555/translate";
+                end_point = "http://127.0.0.1:5555/translate"; //缺省值设置
                 //alert(end_point);//
                 //http://127.0.0.1:5555/api_key_get
             }
@@ -102,24 +103,17 @@
 <body>
     <div class="mask" id="mask"></div>
     <div class="url_setting_block" id="url_setting_block" style="visibility: hidden;">
-        <div class="url_setting_hide" id="url_setting_hide" style="cursor:pointer; position:absolute ;top:20px;left: 30px;width: 20px;height: 20px;"onclick="url_setting_hide_func()">
-            <div class="arrow_image"></div>
+        <label style="font-size: 20px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:30px;width: 100%;text-align: center;">翻译设置</label>
+        <div style="position:absolute; top:50px;left: 30px;">
+            <label style="font-size: 16px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:45px;width: 200px;text-align: left;">服务器：</label>
+            <input type="text" class="url" id="url" rows="1" cols="20"  wrap="off" style="position:absolute; width: 210px;height:21px;letter-spacing: 0px;font-size: 14px;top: 40px; left: 80px"></textarea>
         </div>
-        <div style="position:absolute; top:65px;left: 30px;">
-            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:5px;width: 200px;text-align: left;">服务器端点</label>
-            <textarea class="url" id="url" rows="1" cols="20" placeholder="http://127.0.0.1:5555/translate" wrap="off" style="position:absolute;width: 193.5px;height:21px;letter-spacing: 0px;font-size: 14px;top: 30px;"></textarea>
-            <input type="button" class="url_button" id="url_button" style="position: absolute;top:67px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
+        <div style="position:absolute; top:130px;left: 30px;">
+            <label style="font-size: 16px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:0px;width: 200px;text-align: left;">API KEY：</label>
+            <input type="text" class="api_key" id="api_key" placeholder="api_key" wrap="off" style="position:absolute;font-size: 14px;height:21px;width: 210px;top: 0px;left: 80px"></textarea>
         </div>
-    </div>
-    <div class="api_key_block" id="api_key_block" style="visibility: hidden;">
-        <div class="api_key_hide" id="api_key_hide" style="cursor:pointer; position:absolute ;top:20px;left: 30px;width: 20px;height: 20px;"onclick="api_key_hide_func()">
-            <div class="arrow_image"></div>
-        </div>
-        <div style="position:absolute; top:60px;left: 30px;">
-            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:0px;width: 200px;text-align: left;">输入API密钥</label>
-            <textarea class="api_key" id="api_key" placeholder="api_key" style="position:absolute;font-size: 16px;height:35px;width: 194px;top: 25px;"></textarea>
-            <input type="button" class="api_key_button" id="api_key_button" style="position: absolute;top:77px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="确认" onclick="api_key_check_func()">
-        </div>
+        <input type="button" class="url_setting_hide" style="cursor:pointer; position:absolute ;top:180px;left: 190px; height: 35px; width: 140px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="关闭" onclick="url_setting_hide_func()">
+        <input type="button" class="url_button" id="url_button" style="position: absolute;top:180px;left: 30px ; height: 35px; width: 140px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="设置" onclick="url_resetting_func()">
     </div>
    
     <div class="fanyi__nav">
@@ -137,54 +131,37 @@
                 document.getElementById("mask").style.display='block';
                 console.log("当前翻译地址为："+end_point);
                 //alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
-            }
-            function api_key_func()
-            {
-                document.getElementById("api_key_block").style.visibility='visible';
-                document.getElementById("mask").style.display='block'
+                console.log("当前api_key为："+api_key);
+                end_point = document.getElementById("url").value;
+                if(end_point=="")
+                {
+                    document.getElementById("url").style.placeholder="http://127.0.0.1:5555/translate";
+                }
             }
             
             function url_resetting_func()
             {
                 end_point = document.getElementById("url").value;
-                
                 //var d=JSON.stringify();
                 window.localStorage.setItem("data",end_point);
                 var json=window.localStorage.getItem("data");
-                alert("重置成功！重置后的url为："+json);
+                
                 document.getElementById("url_setting_block").style.visibility='hidden';
-                document.getElementById("mask").style.display='none'
+                document.getElementById("mask").style.display='none';
 
-            }
-            async function api_key_check_func()//
-            {
-                var api_key = document.getElementById("api_key").value;
+                var Api_key = document.getElementById("api_key").value;
+                window.localStorage.setItem("key",Api_key);
+                api_key=Api_key;
 
-                window.localStorage.setItem("key",api_key);
-                //var key=window.localStorage.getItem("key");
-                //alert(key);
-                const res = await fetch("http://127.0.0.1:5555/get_req_api_key", {
-                method: "POST",
-                body: JSON.stringify({api_key:api_key}),
-                headers: { "Content-Type": "application/json" }
-                }
-                );
-                alert("输入成功");
-                url_setting_hide_func();
+                alert("设置成功！url为："+json+"  api-key为:"+api_key);
             }
+         
             function url_setting_hide_func()
             {
                 document.getElementById("url_setting_block").style.visibility='hidden';
                 document.getElementById("mask").style.display='none'
             }
-            function api_key_hide_func()
-            {
-                document.getElementById("api_key_block").style.visibility='hidden';
-                document.getElementById("mask").style.display='none'
-            }
-
             document.getElementById("url_setting_label").addEventListener("click", url_setting_func);
-            document.getElementById("api_key_label").addEventListener("click", api_key_func);
         </script>
     </div>
 

--- a/yimt/service/templates/text.html
+++ b/yimt/service/templates/text.html
@@ -6,11 +6,14 @@
 
     <script>
         var end_point;
-        
+        var api_key;
         window.onload = function()
         {
             var json1=window.localStorage.getItem("data");
+            var json2=window.localStorage.getItem("key");
             //alert(json1);
+            //alert(json2);
+            api_key=json2;
             if(json1=="")
             {
                 end_point = "http://127.0.0.1:5555/translate";
@@ -39,21 +42,27 @@
             }    
         }
         async function translate_func(){
-          qstr = document.getElementById('q').value;
-          qstr = qstr.trim();
-          if(qstr.length==0) return;
-          source_lang = document.getElementById('source').value
-          target_lang = document.getElementById('target').value
-
-          const res = await fetch(end_point, {
-            method: "POST",
-            body: JSON.stringify({q: qstr, source: source_lang, target: target_lang, format: "text"}),
-            headers: { "Content-Type": "application/json" }
-          }
-          );
+            if(api_key=="")
+            {
+                alert("api-key为空！");
+            }
+            else
+            {
+                qstr = document.getElementById('q').value;
+                qstr = qstr.trim();
+                if(qstr.length==0) return;
+                source_lang = document.getElementById('source').value
+                target_lang = document.getElementById('target').value
+                const res = await fetch(end_point, {
+                    method: "POST",
+                    body: JSON.stringify({q: qstr, source: source_lang, target: target_lang, format: "text",api_key:api_key}),
+                    headers: { "Content-Type": "application/json" }
+                }
+                );
           
-          trans_json = await res.json();
-          document.getElementById('translation').value= trans_json.translatedText;
+                trans_json = await res.json();
+                document.getElementById('translation').value= trans_json.translatedText;
+            }
         }
     </script>
     <title>YiMT Translation</title>
@@ -62,32 +71,25 @@
 <body>
     <div class="mask" id="mask"></div>
     <div class="url_setting_block" id="url_setting_block" style="visibility: hidden;">
-        <div class="url_setting_hide" id="url_setting_hide" style="cursor:pointer; position:absolute ;top:20px;left: 30px;width: 20px;height: 20px;"onclick="url_setting_hide_func()">
-            <div class="arrow_image"></div>
+        <label style="font-size: 20px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:30px;width: 100%;text-align: center;">翻译设置</label>
+        <div style="position:absolute; top:50px;left: 30px;">
+            <label style="font-size: 16px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:45px;width: 200px;text-align: left;">服务器：</label>
+            <input type="text" class="url" id="url" rows="1" cols="20"  wrap="off" style="position:absolute; width: 210px;height:21px;letter-spacing: 0px;font-size: 14px;top: 40px; left: 80px"></textarea>
         </div>
-        <div style="position:absolute; top:65px;left: 30px;">
-            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:5px;width: 200px;text-align: left;">服务器端点</label>
-            <textarea class="url" id="url" rows="1" cols="20" placeholder="http://127.0.0.1:5555/translate" wrap="off" style="position:absolute;width: 193.5px;height:21px;letter-spacing: 0px;font-size: 14px;top: 30px;"></textarea>
-            <input type="button" class="url_button" id="url_button" style="position: absolute;top:67px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="重置地址" onclick="url_resetting_func()">
+        <div style="position:absolute; top:130px;left: 30px;">
+            <label style="font-size: 16px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:0px;width: 200px;text-align: left;">API KEY：</label>
+            <input type="text" class="api_key" id="api_key" placeholder="api_key" wrap="off" style="position:absolute;font-size: 14px;height:21px;width: 210px;top: 0px;left: 80px"></textarea>
         </div>
+        <input type="button" class="url_setting_hide" style="cursor:pointer; position:absolute ;top:180px;left: 190px; height: 35px; width: 140px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="关闭" onclick="url_setting_hide_func()">
+        <input type="button" class="url_button" id="url_button" style="position: absolute;top:180px;left: 30px ; height: 35px; width: 140px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="设置" onclick="url_resetting_func()">
     </div>
-    <div class="api_key_block" id="api_key_block" style="visibility: hidden;">
-        <div class="api_key_hide" id="api_key_hide" style="cursor:pointer; position:absolute ;top:20px;left: 30px;width: 20px;height: 20px;"onclick="api_key_hide_func()">
-            <div class="arrow_image"></div>
-        </div>
-        <div style="position:absolute; top:60px;left: 30px;">
-            <label style="font-size: 14px; color: rgb(130, 130, 130);position: absolute;left: 0px;top:0px;width: 200px;text-align: left;">输入API密钥</label>
-            <textarea class="api_key" id="api_key" placeholder="api_key" style="position:absolute;font-size: 16px;height:35px;width: 194px;top: 25px;"></textarea>
-            <input type="button" class="api_key_button" id="api_key_button" style="position: absolute;top:77px; height: 35px; width: 200px; background-color: #357aa1; border-radius: 3px;border:none;cursor:pointer;color: #ffffff;"  value="确认" onclick="api_key_check_func()">
-        </div>
-    </div>
+   
     <div class="fanyi__nav">
         <div class="fanyi__nav__container">
                 <a href="/" class="fanyi__nav__logo"></a>
                 <div class="nav_left">
                     <a target="_blank" class="nav" href="/">文本翻译</a><a target="_blank" class="nav" id="api_key_label">翻译API</a><a target="_blank" class="nav" href="/">登录</a><a target="_blank" id="url_setting_label" class="nav" >设置服务器地址</a>
-                </div>
-                
+                </div>  
         </div>
         <script>
             function url_setting_func()
@@ -96,54 +98,37 @@
                 document.getElementById("mask").style.display='block';
                 console.log("当前翻译地址为："+end_point);
                 //alert("当前翻译地址为："+end_point);//这里测试显示当前翻译地址
-            }
-            function api_key_func()
-            {
-                document.getElementById("api_key_block").style.visibility='visible';
-                document.getElementById("mask").style.display='block'
+                console.log("当前api_key为："+api_key);
+                end_point = document.getElementById("url").value;
+                if(end_point=="")
+                {
+                    document.getElementById("url").style.placeholder="http://127.0.0.1:5555/translate";
+                }
             }
             
             function url_resetting_func()
             {
                 end_point = document.getElementById("url").value;
-                
                 //var d=JSON.stringify();
                 window.localStorage.setItem("data",end_point);
                 var json=window.localStorage.getItem("data");
-                alert("重置成功！重置后的url为："+json);
+                
                 document.getElementById("url_setting_block").style.visibility='hidden';
-                document.getElementById("mask").style.display='none'
+                document.getElementById("mask").style.display='none';
 
-            }
-            async function api_key_check_func()//
-            {
-                var api_key = document.getElementById("api_key").value;
+                var Api_key = document.getElementById("api_key").value;
+                window.localStorage.setItem("key",Api_key);
+                api_key=Api_key;
 
-                window.localStorage.setItem("key",api_key);
-                //var key=window.localStorage.getItem("key");
-                //alert(key);
-                const res = await fetch("http://127.0.0.1:5555/get_req_api_key", {
-                method: "POST",
-                body: JSON.stringify({api_key:api_key}),
-                headers: { "Content-Type": "application/json" }
-                }
-                );
-                alert("输入成功");
-                url_setting_hide_func();
+                alert("设置成功！url为："+json+"  api-key为:"+api_key);
             }
+         
             function url_setting_hide_func()
             {
                 document.getElementById("url_setting_block").style.visibility='hidden';
                 document.getElementById("mask").style.display='none'
             }
-            function api_key_hide_func()
-            {
-                document.getElementById("api_key_block").style.visibility='hidden';
-                document.getElementById("mask").style.display='none'
-            }
-
             document.getElementById("url_setting_label").addEventListener("click", url_setting_func);
-            document.getElementById("api_key_label").addEventListener("click", api_key_func);
         </script>
     </div>
 


### PR DESCRIPTION
1、合并重做 翻译地址、APIkey设置界面
2、翻译地址、APIkey的输入栏改用input type:text组件，实现可编辑无滑动条的单行输入框
3、翻译地址没有保存值编辑框才显示placeholder固定值
4、APIkey会永久保存到本地，每次开启浏览器读取
5、文本翻译请求json段添加api_key参数
6、若apikey设置了才传递文本翻译请求，没有就不传递，会有提示apikey为空。