### PR TITLE
Image更新 7.15

### DIFF
--- a/yimt/service/static/text.css
+++ b/yimt/service/static/text.css
@@ -368,6 +368,73 @@ body {
     overflow: auto
 }
 
+.img_show{
+    display: none;
+    position: absolute;
+    top: 70px;
+    left: 46px;
+    z-index: 2;
+
+    width: 128px;
+    height: 128px;
+    background: #ba1c1c;
+}
+
+.paste_img{
+    width: 128px;
+    height: 128px;
+    z-index: 3;
+}
+
+.fanyi__operations--image--font{
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 16px;
+    line-height: 34px;
+    text-align: center;
+    width: 128px;
+    height: 34px;
+
+    position: absolute;
+    bottom: 78px;
+    left: 30px;
+    z-index: 2;
+    cursor:pointer;
+
+    background: #ffffff;
+    border-radius: 3px;
+    border: none;
+    font-size: 14px;
+    color: rgb(111, 111, 111)
+}
+
+.fanyi__operations--image{
+    display: inline-block;
+    opacity: 0;
+    vertical-align: middle;
+    margin-left: 16px;
+    text-align: center;
+    width: 128px;
+    height: 34px;
+
+    background: #ee0000;
+    border-radius: 0px;
+    border: none;
+    font-size: 0px;
+    cursor:pointer;
+    color: rgb(49, 49, 49)
+}
+
+.fanyi__operations--image{
+    position: absolute;
+    bottom: 78px;
+    left: 30px;
+    z-index: 3;
+    cursor:pointer;
+}
+
+
+
 .fanyi__operations--file{
     display: inline-block;
     vertical-align: middle;

--- a/yimt/service/templates/file.html
+++ b/yimt/service/templates/file.html
@@ -29,55 +29,55 @@
         var xhr;
        
 		function uploadFile() {
-		  var fileObj = document.getElementById("select_file").files[0];
-          var files = document.getElementById("select_file").files;
-          if(files.length==0)
-          {
-            return;
-          }
-          document.getElementById("showProgress").style.display ="block";
-          document.getElementById("progress_line").style.display ="block";
-          document.getElementById("download").style.display = "none";
-
-          source_lang = document.getElementById('source').value;
-          target_lang = document.getElementById('target').value;
-
-          END_POINT = window.localStorage.getItem("server");
-          API_KEY = window.localStorage.getItem("key");
-          if(END_POINT=="")
-          {
-            END_POINT = "http://127.0.0.1:5555";
-          }
-
-		  console.log(fileObj);
-		  var form = new FormData();
-		  form.append("file", fileObj);
-		  form.append("source", source_lang);
-		  form.append("target", target_lang);
-          form.append("api_key", API_KEY);
-
-		  var url = END_POINT + "/translate_file";
-		  xhr = new XMLHttpRequest();
-
-          xhr.upload.addEventListener("progress", function(evt){
-            if (evt.lengthComputable) {
-                var percentComplete = Math.round(evt.loaded * 100 / evt.total);
-                if (percentComplete == 100){
-                    setTimeout(function () {
-                    document.getElementById("showProgress").innerHTML = '上传完成，正在翻译...';
-                    document.getElementById("progress_line").value=percentComplete;
-                },10)
-                }else{
-                    document.getElementById("showProgress").innerHTML = '已上传'+percentComplete+"%";
-                    document.getElementById("progress_line").value=percentComplete;
-                }
-             }else {
-                document.getElementById("showProgress").innerHTML = '无法计算';
+		    var fileObj = document.getElementById("select_file").files[0];
+            var files = document.getElementById("select_file").files;
+            if(files.length==0)
+            {
+                return;
             }
-            }, false);
-		  xhr.open("post", url, true);
-		  xhr.onload = uploadComplete;
-		  xhr.send(form);
+            document.getElementById("showProgress").style.display ="block";
+            document.getElementById("progress_line").style.display ="block";
+            document.getElementById("download").style.display = "none";
+
+            source_lang = document.getElementById('source').value;
+            target_lang = document.getElementById('target').value;
+
+            END_POINT = window.localStorage.getItem("server");
+            API_KEY = window.localStorage.getItem("key");
+            if(END_POINT=="")
+            {
+                END_POINT = "http://127.0.0.1:5555";
+            }
+
+		    console.log(fileObj);
+		    var form = new FormData();
+		    form.append("file", fileObj);
+		    form.append("source", source_lang);
+		    form.append("target", target_lang);
+            form.append("api_key", API_KEY);
+
+		    var url = END_POINT + "/translate_file";
+		    xhr = new XMLHttpRequest();
+
+            xhr.upload.addEventListener("progress", function(evt){
+                if (evt.lengthComputable) {
+                    var percentComplete = Math.round(evt.loaded * 100 / evt.total);
+                    if (percentComplete == 100){
+                        setTimeout(function () {
+                        document.getElementById("showProgress").innerHTML = '上传完成，正在翻译...';
+                        document.getElementById("progress_line").value=percentComplete;
+                    },10)
+                    }else{
+                        document.getElementById("showProgress").innerHTML = '已上传'+percentComplete+"%";
+                        document.getElementById("progress_line").value=percentComplete;
+                    }
+                }else {
+                    document.getElementById("showProgress").innerHTML = '无法计算';
+                }
+                }, false);
+		    xhr.open("post", url, true);
+		    xhr.onload = uploadComplete;
+		    xhr.send(form);
 		}
 
 		function uploadComplete(evt) {

--- a/yimt/service/templates/text.html
+++ b/yimt/service/templates/text.html
@@ -36,6 +36,51 @@
             }    
         }
 
+        var xhr;
+
+        function uploadImage(){
+            var fileObj = document.getElementById("select_image").files[0];
+            var files = document.getElementById("select_image").files;
+            if(files.length==0)
+            {
+                return;
+            }
+            source_lang = document.getElementById('source').value;
+            target_lang = document.getElementById('target').value;
+
+            END_POINT = window.localStorage.getItem("server");
+            API_KEY = window.localStorage.getItem("key");
+            if(END_POINT=="")
+            {
+                END_POINT = "http://127.0.0.1:5555";
+            }
+		    console.log(fileObj);
+		    var form = new FormData();
+		    form.append("file", fileObj);
+		    form.append("source", source_lang);
+		    form.append("target", target_lang);
+            form.append("api_key", API_KEY);
+
+		    var url = END_POINT + "/translate_image";
+		    xhr = new XMLHttpRequest();
+		    xhr.open("post", url, true);
+		    xhr.onload = uploadComplete;
+		    xhr.send(form);
+        }
+
+        function uploadComplete(evt) {
+			//alert(evt.target.responseText);
+			res_json = JSON.parse(evt.target.responseText);
+			if(res_json.error){
+			  alert(res_json.error);
+			  return;
+			}
+			//alert(res_json)
+			//alert(res_json.originalText);
+            document.getElementById('q').value = res_json.originalText;
+            document.getElementById('translation').value = res_json.translatedText;
+		}
+
         async function translate_func(){
             qstr = document.getElementById('q').value;
             qstr = qstr.trim();
@@ -79,13 +124,13 @@
         <input type="button" class="url_setting_hide" value="关闭" onclick="url_setting_hide_func()">
         <input type="button" class="url_button" id="url_button" value="设置" onclick="url_resetting_func()">
     </div>
-   
+
     <div class="fanyi__nav">
         <div class="fanyi__nav__container">
                 <a href="/" class="fanyi__nav__logo"></a>
                 <div class="nav_left">
                     <a target="_blank" class="nav" href="/file">文档翻译</a><a target="_blank" class="nav">翻译API</a><a target="_blank" class="nav" href="/">登录</a><a target="_blank" id="url_setting_label" class="nav" >设置</a>
-                </div>  
+                </div>
         </div>
         <script>
             function url_setting_func()
@@ -95,19 +140,19 @@
                 document.getElementById("url").value=END_POINT;
                 document.getElementById("api_key").value=API_KEY;
             }
-            
+
             function url_resetting_func()
             {
                 END_POINT = document.getElementById("url").value;
                 window.localStorage.setItem("server", END_POINT);
-                
+
                 document.getElementById("url_setting_block").style.visibility='hidden';
                 document.getElementById("mask").style.display='none';
 
                 API_KEY = document.getElementById("api_key").value;
                 window.localStorage.setItem("key",API_KEY);
             }
-         
+
             function url_setting_hide_func()
             {
                 document.getElementById("url_setting_block").style.visibility='hidden';
@@ -188,7 +233,7 @@
                         function getc_num()
                         {
                             document.getElementById("c1").innerHTML=document.getElementById("q").value.length;
-                        }         
+                        }
                     </script>
 
                     <a id="inputDelete" class="input__original_delete"></a>
@@ -201,11 +246,56 @@
                             document.getElementById("q").value='';
                             document.getElementById("translation").value='';
                             getc_num();
-                        }    
+                        }
                         document.getElementById("inputDelete").addEventListener("click", clear_func);
+
+                        document.getElementById("q").addEventListener('paste',function(e){
+                            var data = e.clipboardData||window.clipboardData;
+                            var blob = data.items[0].getAsFile();
+                            var isImg = (blob&&1)||-1;
+                            //alert(isImg);
+                            var reader = new FileReader();
+                            if(isImg >= 0)
+                            {       
+                                reader.readAsDataURL(blob);
+                            }
+                            reader.onload = function(evt)
+                            {
+                                var base64_str = evt.target.result;
+                                console.log(base64_str);
+                                document.getElementById("q").value = "";
+                                document.getElementById("paste_img").src = base64_str;
+                                document.getElementById("img_show").style.display='block';
+                                
+                                /*
+                                source_lang = document.getElementById('source').value;
+                                target_lang = document.getElementById('target').value;
+                                END_POINT = window.localStorage.getItem("server");
+                                API_KEY = window.localStorage.getItem("key");
+                                if(END_POINT=="")
+                                {
+                                    END_POINT = "http://127.0.0.1:5555";
+                                }  
+                                var form = new FormData();
+		                        form.append("base64", base64_str);
+		                        form.append("source", source_lang);
+		                        form.append("target", target_lang);
+                                form.append("api_key", API_KEY);                     
+                                var url = END_POINT + "/translate_image";
+		                        xhr = new XMLHttpRequest();
+		                        xhr.open("post", url, true);
+		                        xhr.onload = uploadComplete;
+		                        xhr.send(form);
+                                */
+                            }
+                        });
                     </script>
                 </div>
-                
+                <div class="img_show" id="img_show">
+                    <img class="paste_img" id="paste_img" src="">
+                </div>
+                <div class="fanyi__operations--image--font" >翻译图片</div>
+                <input type="file" id="select_image" class="fanyi__operations--image" onchange="uploadImage()">
                 <!--<input type="button" value="翻译文档" class="fanyi__operations--file" onclick="window.location.href='/file'">-->
             </div>
 


### PR DESCRIPTION
1、前端实现、优化了文件上传按钮样式，点击按钮上传图片文件。
2、后端新增translate_image()接口，通过点击前端“翻译照片”按钮上传照片文件到后端，返回照片内原文本和翻译文本（这里方便测试暂设置为返回固定字符串），分别显示在源、目标语言文本框中。已通过本地测试。
3、前端实现了在源语言文本框里粘贴图片，流处理，并在源语言文本框显示缩略图，（注：此功能不支持文件夹保存的图片的剪贴。）如何继续把此图片上传到后端，还在尝试实现中。