### PR TITLE
Web开发更新：实现语言选项面板和Json设置

### DIFF
--- a/yimt/service/static/lang_options.json
+++ b/yimt/service/static/lang_options.json
@@ -1,0 +1,15 @@
+{
+    "options": [
+      ["Chinese", "English", "Japanese", "Korean", "German"],
+      ["Vietnamese", "Russian", "Arabic", "Spanish", "French"],
+      ["Portuguese", "Malay", "Hindi", "Italian", "Thai"],
+      ["Indonesian"]
+    ],
+    "lang_options": [
+      ["zh", "en", "ja", "ko", "de"],
+      ["vi", "ru", "ar", "es", "fr"],
+      ["pt", "ms", "hi", "it", "th"],
+      ["id"]
+    ]
+
+}

--- a/yimt/service/static/text.css
+++ b/yimt/service/static/text.css
@@ -207,14 +207,15 @@ body {
 .source_select{
     display: inline-block;
     vertical-align: middle;
-    margin-left: 0px;
+    margin-left: 8px;
     text-align: center;
     width: 148px;
     height: 38px;
     line-height: 38px;
     background: #ffffff;
     border-radius: 3px;
-    font-size: 14px;
+    border: 1px solid rgb(65, 65, 65);
+    font-size: 17px;
     color: rgb(39, 39, 39);
     cursor:pointer;
 }
@@ -229,7 +230,8 @@ body {
     line-height: 38px;
     background: #ffffff;
     border-radius: 3px;
-    font-size: 14px;
+    border: 1px solid rgb(65, 65, 65);
+    font-size: 17px;
     color: rgb(39, 39, 39);
     cursor:pointer;
 }
@@ -780,4 +782,66 @@ body {
     text-align: center;
 }
 
+/*
+#option-table  {
+    position: absolute;
+    top:100px;
+    left: 10%;
+    transform: translate(-50%, -50%);
+    width: 1400px;
+    height: 700px;
+    margin-left: 60px;
+    margin-right: 60px;
+    padding: 20px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    display: none; 
+    z-index: 8;
+}
+#option-table {
+    border-collapse: collapse; 
+   width: 100%;  表格宽度
+    margin-bottom: 20px; 
+}
+*/
+#option-table {
+    position: absolute;
+    min-width: 560px;
+    max-width: 700px;
+    top:150px;
+    width: 60%;
+    height: 300px;
+    margin-left: 10%;
+    margin-right:10%;
+    padding: 40px;
+    padding-left: 80px;
+    opacity: 1;
+    background-color: #ffffff;
+    /*
+    margin-left: 170px;
+    margin-right: 60px;*/
+    z-index: 8;
+    display: none; 
+    border-radius: 6px;
+    border: 1px solid  #565656
+    
 
+}
+
+#option-table td {
+    padding: 10px; /* 单元格内边距 */
+    font-size: 18px;
+    color: #212121;
+    width: 115px;
+    height: 35px;
+    text-align: center;
+    border-radius: 2px;
+    border: 1px solid transparent
+}
+
+#option-table td:hover {
+    background-color: #357aa1; 
+    color: #ffffff;
+    cursor: pointer;
+}

--- a/yimt/service/templates/text.html
+++ b/yimt/service/templates/text.html
@@ -7,6 +7,10 @@
     <script src="../static/common_block.js" type="text/javascript"></script>
     <script src="../static/func.js" type="text/javascript"></script>
 
+    <!-- jquery -->
+    <script type="text/javascript" src="../static/plugin/jquery-2.2.1.min.js"></script>
+    <script type="text/javascript" src="../static/plugin/jquery.media.js"></script>
+
     <script>
         var API_KEY = "";
         var END_POINT = "http://127.0.0.1:5555";
@@ -131,47 +135,93 @@
     </div>
 
     <div class="restriction">
+        <div class="option-table" id="option-table"></div>
+        <div class="option-window" id="option-window"></div>
         <div class="fanyi__operations">
             <div class="fanyi__operations--left">
                 <div id="toolbar">
-                    <select id="source" name="source" class="source_select">
-                        <option value="auto">自动检测</option>
-                        <option value="zh">Chinese</option>
-                        <option value="en">English</option>
-                        <option value="ja">Japanese</option>
-                        <option value="ko">Korean</option>
-                        <option value="de">German</option>
-                        <option value="vi">Vietnamese</option>
-                        <option value="ru">Russian</option>
-                        <option value="ar">Arabic</option>
-                        <option value="es">Spanish</option>
-                        <option value="fr">French</option>
-                        <option value="pt">Portuguese</option>
-                        <option value="ms">Malay</option>
-                        <option value="hi">Hindi</option>
-                        <option value="it">Italian</option>
-                        <option value="th">Thai</option>
-                        <option value="id">Indonesian</option>
-                    </select>
+                    <button id="source" name="source" class="source_select" value="auto" onclick="openTableWindow(0)">自动检测</button>
                     <span class="mid">-></span>
-                    <select id="target" name="target" class="target_select">
-                        <option value="zh">Chinese</option>
-                        <option value="en">English</option>
-                        <option value="ja">Japanese</option>
-                        <option value="ko">Korean</option>
-                        <option value="de">German</option>
-                        <option value="vi">Vietnamese</option>
-                        <option value="ru">Russian</option>
-                        <option value="ar">Arabic</option>
-                        <option value="es">Spanish</option>
-                        <option value="fr">French</option>
-                        <option value="pt">Portuguese</option>
-                        <option value="ms">Malay</option>
-                        <option value="hi">Hindi</option>
-                        <option value="it">Italian</option>
-                        <option value="th">Thai</option>
-                        <option value="id">Indonesian</option>
-                    </select>
+                    <button id="target" name="target" class="target_select" value="zh" onclick="openTableWindow(1)">Chinese</button>
+                    
+                    <script>
+                        /*var options = [
+                            ['Chinese', 'English', 'Japanese','Korean','German'],
+                            ['Vietnamese', 'Russian', 'Arabic','Spanish','French'],
+                            ['Portuguese', 'Malay','Hindi','Italian','Thai'],
+                            ['Thai']
+                        ];*/
+
+                        function renderOptionTable(options, lang_options, query_type) {
+                            var optionTable = document.getElementById('option-table');
+                            optionTable.innerHTML = '';
+                            var selected_lang = "zh";
+                            var numRows = options.length
+                            //console.log(query_type)
+                            for (var i = 0; i < numRows; i++){
+                                var row = document.createElement('tr');
+                                for (var j = 0; j < options[i].length; j++){
+                                    var cell = document.createElement('td');
+                                    cell.textContent = options[i][j];
+                                    cell.style.textAlign = 'left';
+                                    (function(i, j) {
+                                        cell.addEventListener('click', function() {
+                                            var selectedOption = this.textContent;
+                                            selected_lang = lang_options[i][j];
+                                            if(query_type == "target"){
+                                                document.getElementById('target').innerText = selectedOption;
+                                                document.getElementById('target').value = selected_lang
+                                                console.log("target_lang:"+ document.getElementById('target').value);
+                                            }
+                                            else{
+                                                document.getElementById('source').innerText = selectedOption;
+                                                document.getElementById('source').value = selected_lang
+                                                console.log("source_lang:"+ document.getElementById('source').value);
+                                            }
+                                            document.getElementById('option-table').style.display = 'none';
+                                        });
+                                    })(i, j);
+                                    row.appendChild(cell)
+                                }
+                                optionTable.appendChild(row) 
+                            }  
+                        }    
+                        
+                        
+                        function loadOptionsFromJSON(query_type) {
+                            var xhr = new XMLHttpRequest();
+                            xhr.overrideMimeType('application/json');
+                            //json_path = "../static/lang_options.json"
+                            xhr.open('GET', "../static/lang_options.json", true);
+                            xhr.onreadystatechange = function () {
+                                if (xhr.readyState === 4 && xhr.status === 200) {
+                                    var optionsData = JSON.parse(xhr.responseText);
+                                    var options = optionsData.options;
+                                    var lang_options = optionsData.lang_options;
+                                    //console.log(options)
+                                    if(query_type==1){
+                                        query = "target";
+                                    }
+                                    else{
+                                        query = "source";
+                                    }
+                                    renderOptionTable(options, lang_options, query);
+                                }
+                            };
+                            xhr.send();
+                        }
+
+                        var selectedOption = null;
+                        function openTableWindow(query_type) {
+                            //alert(query_type);
+                            //console.log(options)
+                            loadOptionsFromJSON(query_type);
+                            //const jsonFile = "lang_options.json"; // JSON 文件的路径
+                            document.getElementById('option-table').style.display = 'block';
+                           
+                        }
+                        
+                    </script>
                     <input type="button" class="fanyi__operations--machine" id="transMachine" value="翻译" onclick='translate_func()'>
 
                 </div>


### PR DESCRIPTION
1、实现前端语言选项界面，替代原有的select组件，有跳出、关闭，鼠标悬停模块颜色变化逻辑。
2、语言选项面板基于表格，可以自行根据语言列表组成进行布局，而不用另行设置布局。
3、语言类列表和对应2字母编码存储在lang_option.Json中，页面运行时进一步载入到js代码块中。

注：目前在text.html应用了改动，如果之后没问题再进一步应用到flie.html中。